### PR TITLE
Test installing DragoNN from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ python:
 
 install:
   # Install the cloned dragonn package from source
-  - pip install .
+  # Process the deeplift dependency_links in setup.py
+  - pip install . --process-dependency-links
 
 # Do not test the package functionality, simply run an arbitrary tutorial function
 script: python -c 'from dragonn.tutorial_utils import print_available_simulations; print_available_simulations()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,11 @@ before_install:
   # Install in batch mode
   - ./miniconda.sh -b  -p $HOME/miniconda
   - export PATH=$HOME/miniconda/bin:$PATH
-  - which python
   - conda update --yes conda
 
 install:
-  # Install Theano dependency in advance
-  # pip cannot easily install scipy on the Travis CI server
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION scipy
+  # pip cannot easily install scipy or matplotlib on the Travis CI server
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION scipy matplotlib
   # Install the cloned dragonn package from source using Anaconda
   # Process the deeplift dependency_links in setup.py
   - pip install . --process-dependency-links

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,27 @@
 # Config file for automatic testing at travis-ci.org
+# Conda testing for Travis CI from https://gist.github.com/dan-blanchard/7045057
 language: python
 
 python:
-  - "2.7"
+  - 2.7
+
+notifications:
+  email: false
+  
+# Setup Anaconda
+before_install:
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  # Install in batch mode
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/miniconda/bin:$PATH
+  - conda update --yes conda
 
 install:
-  # Install the cloned dragonn package from source
+  # Install Theano dependency in advance
+  # pip cannot easily install scipy on the Travis CI server
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION scipy
+  # Install the cloned dragonn package from source using Anaconda
   # Process the deeplift dependency_links in setup.py
   - pip install . --process-dependency-links
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+# Config file for automatic testing at travis-ci.org
+language: python
+
+python:
+  - "2.7"
+
+install:
+  # Install the cloned dragonn package from source
+  - pip install .
+
+# Do not test the package functionality, simply run an arbitrary tutorial function
+script: python -c 'from dragonn.tutorial_utils import print_available_simulations; print_available_simulations()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   # Install in batch mode
-  - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda/bin:$PATH
+  - ./miniconda.sh -b  -p $HOME/miniconda
+  - export PATH=$HOME/miniconda/bin:$PATH
+  - which python
   - conda update --yes conda
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ config = {
     'packages': ['dragonn', 'dragonn.synthetic'],
     'package_data': {'dragonn.synthetic': ['motifs.txt.gz']},
     'setup_requires': [],
-    'install_requires': ['numpy>=1.9', 'keras==0.3.2', 'deeplift', 'shapely'],
+    'install_requires': ['numpy>=1.9', 'keras==0.3.2', 'deeplift', 'shapely', 'matplotlib'],
     'dependency_links': ['https://github.com/kundajelab/deeplift/tarball/master#egg=deeplift-0.2'],
     'scripts': [],
     'name': 'dragonn'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ config = {
     'packages': ['dragonn', 'dragonn.synthetic'],
     'package_data': {'dragonn.synthetic': ['motifs.txt.gz']},
     'setup_requires': [],
-    'install_requires': ['numpy>=1.9', 'keras==0.3.2', 'deeplift', 'shapely', 'matplotlib'],
+    'install_requires': ['numpy>=1.9', 'keras==0.3.2', 'deeplift', 'shapely', 'matplotlib', 'sklearn'],
     'dependency_links': ['https://github.com/kundajelab/deeplift/tarball/master#egg=deeplift-0.2'],
     'scripts': [],
     'name': 'dragonn'


### PR DESCRIPTION
Added Travis CI support to test installing DragoNN from source on a fresh machine.  This required minor modifications to `setup.py` as well to add additional required packages.