### PR TITLE
Add Python 3 support via future package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 __pycache__/
-.pyc
+*.pyc
 .ipynb_checkpoints
 .idea
+
+# Setuptools
+build
+dist
+*egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 
 python:
   - 2.7
+  - 3.5
 
 notifications:
   email: false
@@ -19,7 +20,9 @@ before_install:
 
 install:
   # pip cannot easily install scipy, matplotlib or graphviz on the Travis CI server
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION scipy matplotlib graphviz
+  - conda create -n dragonn --yes python=$TRAVIS_PYTHON_VERSION scipy matplotlib graphviz
+  # switch to virtual env
+  - source activate dragonn
   # Install the cloned dragonn package from source using Anaconda
   # Process the deeplift dependency_links in setup.py
   - pip install . --process-dependency-links

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 
 notifications:
   email: false
-  
+
 # Setup Anaconda
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/dragonn/__main__.py
+++ b/dragonn/__main__.py
@@ -27,6 +27,8 @@ def parse_args():
                                     help='weights hd5 file')
     # define commands 
     subparsers = parser.add_subparsers(help='dragonn command help', dest='command')
+    subparsers.required = True #http://bugs.python.org/issue9253#msg186387
+
     train_parser = subparsers.add_parser('train',
                                          parents=[fasta_pair_parser, prefix_parser],
                                          help='model training help')

--- a/dragonn/__main__.py
+++ b/dragonn/__main__.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import argparse
 import numpy as np
 np.random.seed(1)

--- a/dragonn/hyperparameter_search.py
+++ b/dragonn/hyperparameter_search.py
@@ -1,11 +1,15 @@
 from __future__ import absolute_import, division, print_function
+
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object, range
+from future.utils import with_metaclass
+
 import numpy as np, sys
 from abc import abstractmethod, ABCMeta
 
 
-class HyperparameterBackend(object):
-    __metaclass__ = ABCMeta
-
+class HyperparameterBackend(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def __init__(self, grid):
         pass
@@ -31,7 +35,7 @@ class RandomSearch(HyperparameterBackend):
 
 
 if sys.version_info[0] == 2:
-    from httplib import BadStatusLine
+    from http.client import BadStatusLine
     from moe.easy_interface.experiment import Experiment
     from moe.easy_interface.simple_endpoint import gp_next_points
     from moe.optimal_learning.python.data_containers import SamplePoint
@@ -101,7 +105,7 @@ class HyperparameterSearcher(object):
             task_scores = model.score(self.validation_data[0], self.validation_data[1], self.metric)
             score = task_scores.mean()  # mean across tasks
             # Record hyperparameters and validation loss
-            self.backend.record_result(point=hyperparameters.values(), value=score)
+            self.backend.record_result(point=list(hyperparameters.values()), value=score)
             # If these hyperparameters were the best so far, store this model
             if self.maximize == (score > self.best_score):
                 self.best_score = score

--- a/dragonn/metrics.py
+++ b/dragonn/metrics.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import, division, print_function
+from builtins import zip, object
+
 import numpy as np
 from collections import OrderedDict
 from sklearn.metrics import auc, precision_recall_curve, roc_auc_score

--- a/dragonn/models.py
+++ b/dragonn/models.py
@@ -1,4 +1,9 @@
 from __future__ import absolute_import, division, print_function
+
+from builtins import str, zip, map, object, range
+from future.utils import with_metaclass
+from io import open
+
 import json, matplotlib, numpy as np, os, subprocess, tempfile
 matplotlib.use('pdf')
 import matplotlib.pyplot as plt
@@ -18,9 +23,7 @@ from sklearn.tree import DecisionTreeClassifier as scikit_DecisionTree
 from sklearn.ensemble import RandomForestClassifier
 
 
-class Model(object):
-    __metaclass__ = ABCMeta
-
+class Model(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def __init__(self, **hyperparameters):
         pass
@@ -230,7 +233,7 @@ class SequenceDNN(Model):
                 basewise_max_sequence_scores = sequence_scores.max(axis=0)
                 plt.clf()
                 figure, (top_axis, bottom_axis) = plt.subplots(2)
-                top_axis.plot(range(1, len(basewise_max_sequence_scores) + 1),
+                top_axis.plot(list(range(1, len(basewise_max_sequence_scores) + 1)),
                               basewise_max_sequence_scores)
                 top_axis.set_title('{} scores (motif highlighted)'.format(score_name))
                 peak_position = basewise_max_sequence_scores.argmax()
@@ -269,12 +272,13 @@ class SequenceDNN(Model):
     def save(self, model_fname, weights_fname):
         if 'self' in self.saved_params:
             del self.saved_params['self']
-        json.dump(self.saved_params, open(model_fname, 'wb'), indent=4)
+        with open(model_fname, 'w') as model_fd:
+            json.dump(self.saved_params, model_fd, indent=4)
         self.model.save_weights(weights_fname, overwrite=True)
 
     @staticmethod
     def load(model_fname, weights_fname):
-        model_params = json.load(open(model_fname, 'rb'))
+        model_params = json.load(open(model_fname, 'r'))
         sequence_dnn = SequenceDNN(**model_params)
         sequence_dnn.model.load_weights(weights_fname)
         return sequence_dnn

--- a/dragonn/models.py
+++ b/dragonn/models.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 from builtins import str, zip, map, object, range
 from future.utils import with_metaclass
-from io import open
 
 import json, matplotlib, numpy as np, os, subprocess, tempfile
 matplotlib.use('pdf')

--- a/dragonn/plot.py
+++ b/dragonn/plot.py
@@ -1,3 +1,4 @@
+from builtins import zip, map, range, object
 import re
 
 import matplotlib
@@ -318,6 +319,6 @@ def add_letters_to_axis(ax, letter_heights):
                 y_neg_pos += height
 
     ax.set_xlim(x_range[0] - 1, x_range[1] + 1)
-    ax.set_xticks(range(*x_range) + [x_range[-1]])
+    ax.set_xticks(list(range(*x_range)) + [x_range[-1]])
     ax.set_aspect(aspect='auto', adjustable='box')
     ax.autoscale_view()

--- a/dragonn/synthetic/fileProcessing.py
+++ b/dragonn/synthetic/fileProcessing.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+from builtins import next, str, object
 import re
 import os
 from . import util
@@ -31,7 +32,7 @@ def getFileNameParts(fileName):
     return FileNameParts(m.group(1), m.group(2), m.group(3))
 
 
-class FileNameParts:
+class FileNameParts(object):
 
     def __init__(self, directory, coreFileName, extension):
         self.directory = directory if (directory is not None) else os.getcwd()
@@ -122,7 +123,7 @@ def transformFile(
 # reades a line of the file on-demand.
 
 
-class FileReader:
+class FileReader(object):
 
     def __init__(self, fileHandle, preprocessing=None, filterFunction=None, transformation=lambda x: x, ignoreInputTitle=False):
         self.fileHandle = fileHandle
@@ -551,13 +552,13 @@ class FastaIterator(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         self.lineCount += 1
         printProgress(self.progressUpdate, self.lineCount,
                       self.progressUpdateFileName)
         # should raise StopIteration if at end of lines
-        keyLine = trimNewline(self.fileHandle.next())
-        sequence = trimNewline(self.fileHandle.next())
+        keyLine = trimNewline(next(self.fileHandle))
+        sequence = trimNewline(next(self.fileHandle))
         if (keyLine.startswith(">") == False):
             raise RuntimeError(
                 "Expecting a record name line that begins with > but got " + str(keyLine))

--- a/dragonn/synthetic/pwm.py
+++ b/dragonn/synthetic/pwm.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+from builtins import str, range, object
 from . import util, fileProcessing as fp
 import numpy as np
 import math

--- a/dragonn/synthetic/synthetic.py
+++ b/dragonn/synthetic/synthetic.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+from builtins import str, range, object
 from . import util, pwm, fileProcessing as fp
 import argparse
 import numpy as np

--- a/dragonn/synthetic/util.py
+++ b/dragonn/synthetic/util.py
@@ -1,4 +1,8 @@
 from __future__ import absolute_import, division, print_function
+from future import standard_library
+standard_library.install_aliases()
+from builtins import next, zip, str, range, object
+
 import sys
 import os
 import datetime
@@ -198,7 +202,7 @@ class DiscreteDistribution(object):
             valToFreq: OrderedDict where the keys are the possible things to sample, and the values are their frequencies
         """
         self.valToFreq = valToFreq
-        self.freqArr = valToFreq.values()  # array representing only the probabilities
+        self.freqArr = list(valToFreq.values())  # array representing only the probabilities
         # map from index in freqArr to the corresponding value it represents
         self.indexToVal = dict((x[0], x[1])
                                for x in enumerate(valToFreq.keys()))
@@ -469,7 +473,7 @@ def floatRange(start, end, step):
         val += step
 
 
-class VariableWrapper():
+class VariableWrapper(object):
     """ For when I want reference-type access to an immutable"""
 
     def __init__(self, var):
@@ -882,8 +886,8 @@ class TitledMappingIterator(object):
         self.titledMapping = titledMapping
         self.keysIterator = iter(titledMapping.mapping)
 
-    def next(self):
-        nextKey = self.keysIterator.next()
+    def __next__(self):
+        nextKey = next(self.keysIterator)
         return self.titledMapping.getTitledArrForKey(nextKey)
 
 
@@ -938,7 +942,7 @@ class TitledMapping(object):
 
     def printToFile(self, fileHandle, includeRownames=True):
         import fileProcessing as fp
-        fp.writeMatrixToFile(fileHandle, self.mapping.values(), self.titleArr, [
+        fp.writeMatrixToFile(fileHandle, list(self.mapping.values()), self.titleArr, [
                              x for x in self.mapping.keys()])
 
 
@@ -1283,7 +1287,7 @@ class TeeOutputStreams(object):
 
 
 def redirectStdoutToString(func, logger=None, emailErrorFunc=None):
-    from StringIO import StringIO
+    from io import StringIO
     # takes a function, and returns a wrapper which redirects
     # stdout to something else for that function
     #(the function must execute in a thread)
@@ -1317,7 +1321,7 @@ def redirectStdoutToString(func, logger=None, emailErrorFunc=None):
 
 
 def doesNotWorkForMultithreading_redirectStdout(func, redirectedStdout):
-    from StringIO import StringIO
+    from io import StringIO
     # takes a function, and returns a wrapper which redirects
     # stdout to something else for that function
     #(the function must execute in a thread)
@@ -1585,7 +1589,7 @@ class IterableFromDict(object):
         self.totalLen = totalLen
         self.idx = -1
 
-    def next(self):
+    def __next__(self):
         self.idx += 1
         if self.idx == self.totalLen:
             raise StopIteration()

--- a/dragonn/tutorial_utils.py
+++ b/dragonn/tutorial_utils.py
@@ -1,3 +1,7 @@
+from __future__ import print_function
+from __future__ import division
+from builtins import str, range
+
 import random
 random.seed(1)
 import inspect
@@ -26,7 +30,7 @@ def get_available_simulations():
 
 def print_available_simulations():
     for function_name in get_available_simulations():
-        print function_name
+        print(function_name)
 
 
 def get_simulation_function(simulation_name):
@@ -40,7 +44,7 @@ def get_simulation_function(simulation_name):
 def print_simulation_info(simulation_name):
     simulation_function = get_simulation_function(simulation_name)
     if simulation_function is not None:
-        print simulation_function.func_doc
+        print(simulation_function.__doc__)
 
 
 def get_simulation_data(simulation_name, simulation_parameters,
@@ -71,11 +75,11 @@ def get_simulation_data(simulation_name, simulation_parameters,
 
 
 def inspect_SequenceDNN():
-    print inspect.getdoc(SequenceDNN)
+    print(inspect.getdoc(SequenceDNN))
     print("\nAvailable methods:\n")
     for (method_name, _) in inspect.getmembers(SequenceDNN, predicate=inspect.ismethod):
         if method_name != "__init__":
-            print method_name
+            print(method_name)
 
 
 def get_SequenceDNN(SequenceDNN_parameters):
@@ -95,8 +99,8 @@ def SequenceDNN_learning_curve(dnn):
         min_loss_indx = min(enumerate(dnn.valid_losses), key=lambda x: x[1])[0]
         f = plt.figure(figsize=(10, 4))
         ax = f.add_subplot(1, 1, 1)
-        ax.plot(range(len(dnn.train_losses)), dnn.train_losses, 'b', label='Training',lw=4)
-        ax.plot(range(len(dnn.train_losses)), dnn.valid_losses, 'r', label='Validation', lw=4)
+        ax.plot(list(range(len(dnn.train_losses))), dnn.train_losses, 'b', label='Training',lw=4)
+        ax.plot(list(range(len(dnn.train_losses))), dnn.valid_losses, 'r', label='Validation', lw=4)
         ax.plot([min_loss_indx, min_loss_indx], [0, 1.0], 'k--', label='Early Stop')
         ax.legend(loc="upper right")
         ax.set_ylabel("Loss")
@@ -238,7 +242,7 @@ def interpret_data_with_SequenceDNN(dnn, simulation_data):
     f.set_tight_layout(True)
 
     for j, key in enumerate(['Positive', 'Negative']):
-        for i, (score_type, scores) in enumerate(scores_dict[key].iteritems()):
+        for i, (score_type, scores) in enumerate(scores_dict[key].items()):
             ax = f.add_subplot(plots_per_column, plots_per_row, plots_per_row*i+j+1)
             ax.set_ylim(ylim_dict[score_type])
             ax.set_xlim((0, seq_length))

--- a/dragonn/utils.py
+++ b/dragonn/utils.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+from builtins import range
 import numpy as np
 import sys
 from sklearn.preprocessing import LabelEncoder, OneHotEncoder

--- a/dragonn/visualize_util.py
+++ b/dragonn/visualize_util.py
@@ -96,7 +96,7 @@ class ModelToDot(object):
         if self.recursive and (is_graph or is_seq):
             # We got a container layer, recursively transform it
             if is_graph:
-                child_layers = list(layer.outputs.values())
+                child_layers = layer.outputs.values()
             else:
                 child_layers = [layer.layers[-1]]
             for l in child_layers:

--- a/dragonn/visualize_util.py
+++ b/dragonn/visualize_util.py
@@ -1,3 +1,4 @@
+from builtins import str, object
 # Adapted from Keras source code
 # License: https://github.com/fchollet/keras/blob/master/LICENSE
 
@@ -95,7 +96,7 @@ class ModelToDot(object):
         if self.recursive and (is_graph or is_seq):
             # We got a container layer, recursively transform it
             if is_graph:
-                child_layers = layer.outputs.values()
+                child_layers = list(layer.outputs.values())
             else:
                 child_layers = [layer.layers[-1]]
             for l in child_layers:

--- a/scripts/download_model_binary.py
+++ b/scripts/download_model_binary.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python
 # Adapted from caffe source code
 # License: https://github.com/BVLC/caffe/blob/master/LICENSE 
+from __future__ import print_function
+from __future__ import division
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
+
 import os
 import sys
 import time
 import yaml
-import urllib
+import urllib.request
 import hashlib
 import argparse
 
@@ -71,7 +77,7 @@ if __name__ == '__main__':
         sys.exit(0)
 
     # Download and verify model.
-    urllib.urlretrieve(
+    urllib.request.urlretrieve(
         frontmatter['weights_url'], model_filename, reporthook)
     if not model_checks_out():
         print('ERROR: model did not download correctly! Run this again.')

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ config = {
     'package_data': {'dragonn.synthetic': ['motifs.txt.gz']},
     'setup_requires': [],
     'install_requires': ['numpy>=1.9', 'keras==0.3.2', 'deeplift', 'shapely', 'matplotlib',
-                         'sklearn', 'pyprg', 'pydot_ng'],
+                         'sklearn', 'pyprg', 'pydot_ng', 'future'],
     'dependency_links': ['https://github.com/kundajelab/deeplift/tarball/master#egg=deeplift-0.2'],
     'scripts': [],
     'entry_points': {'console_scripts': ['dragonn = dragonn.__main__:main']},


### PR DESCRIPTION
I added proper Python 3 support using the [future](python-future.org/overview.html) package. Please consider switching to Python 3 [by default](https://python3statement.github.io/), before many contributors get involved. Such cool projects shouldn't set out with Python 2 and encourage it. I think except for [MOE](https://github.com/Yelp/MOE/), there is no reason to stick to Python 2. For MOE, I already made an attempt to port it into Python 3, see https://github.com/Yelp/MOE/issues/466. I hope it'll be integrated at some point.
