### PR TITLE
Update ENCODE_MOTIFS_PATH for simbna.

### DIFF
--- a/dragonn/plot.py
+++ b/dragonn/plot.py
@@ -280,7 +280,7 @@ def plot_motif(motif_name, figsize, ylab='bits', information_content=True):
     Plot motifs from encode motifs file
     """
     ENCODE_MOTIFS_PATH = resource_filename(
-        'dragonn.synthetic', 'motifs.txt.gz')
+        'simdna.synthetic', 'motifs.txt.gz')
     loaded_motifs = LoadedEncodeMotifs(
         ENCODE_MOTIFS_PATH, pseudocountProb=0.001)
     motif_letter_heights = loaded_motifs.getPwm(motif_name).getRows()


### PR DESCRIPTION
In the tutorial notebook, the command
`interpret_SequenceDNN_filters(multi_filter_dragonn, simulation_data)`
leads to the error
`ImportError: No module named synthetic`