### PR TITLE
Travis CI tests in Python 2.7 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,17 @@ before_install:
   - conda update --yes conda
 
 install:
-  # pip cannot easily install scipy, matplotlib or graphviz on the Travis CI server
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION scipy matplotlib graphviz pytest
-  # Install the cloned dragonn package from source using Anaconda
+  # Create a conda environment for the desired Python version and install
+  # The dependencies that pip cannot easily install on the Travis CI server
+  - conda create --yes --name dragonn-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION scipy matplotlib graphviz pytest
+  # Use the new environment
+  - source activate dragonn-$TRAVIS_PYTHON_VERSION
+  - python --version
+  # Install the cloned dragonn package from source
   # Process the deeplift dependency_links in setup.py
   - pip install . --process-dependency-links
 
-# run dragonn binary and tests
+# Run dragonn binary and tests
 script:
 - dragonn --help
 - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,17 @@ before_install:
 
 install:
   # Create a conda environment for the desired Python version and install
-  # The dependencies that pip cannot easily install on the Travis CI server
+  # the dependencies that pip cannot easily install on the Travis CI server
   - conda create --yes --name dragonn-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION scipy matplotlib=1.5.3 pytest
   # Use the new environment
   - source activate dragonn-$TRAVIS_PYTHON_VERSION
+  # Confirm the Python version
   - python --version
   # Install the cloned dragonn package from source
-  # Process the deeplift dependency_links in setup.py
+  # Process the deeplift and dependency_links in setup.py
+  # Note that Dependency Links processing has been deprecated per
+  # https://github.com/pypa/pip/issues/3939 so this will need to be updated in
+  # the future
   - pip install . --process-dependency-links
 
 # Run dragonn binary and tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 install:
   # Create a conda environment for the desired Python version and install
   # the dependencies that pip cannot easily install on the Travis CI server
-  - conda create --yes --name dragonn-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION scipy matplotlib=1.5.3 pytest
+  - conda create --yes --name dragonn-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION scipy matplotlib=1.5.3 pytest Shapely
   # Use the new environment
   - source activate dragonn-$TRAVIS_PYTHON_VERSION
   # Confirm the Python version

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   # Confirm the Python version
   - python --version
   # Install the cloned dragonn package from source
-  # Process the deeplift and dependency_links in setup.py
+  # Process the deeplift and simdna dependency_links in setup.py
   # Note that Dependency Links processing has been deprecated per
   # https://github.com/pypa/pip/issues/3939 so this will need to be updated in
   # the future

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 
 python:
   - 2.7
+  - 3.5
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,16 @@ notifications:
   
 # Setup Anaconda
 before_install:
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   # Install in batch mode
   - ./miniconda.sh -b  -p $HOME/miniconda
   - export PATH=$HOME/miniconda/bin:$PATH
-  - conda update --yes conda
 
 install:
   # Create a conda environment for the desired Python version and install
   # The dependencies that pip cannot easily install on the Travis CI server
-  - conda create --yes --name dragonn-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION scipy matplotlib graphviz pytest
+  - conda create --yes --name dragonn-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION scipy matplotlib=1.5.3 pytest
   # Use the new environment
   - source activate dragonn-$TRAVIS_PYTHON_VERSION
   - python --version

--- a/tests/test_architectures.py
+++ b/tests/test_architectures.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, division, print_function
-import numpy as np, os, pytest, random
+import numpy as np, os, pytest, random, sys
 os.environ["THEANO_FLAGS"] = "device=cpu"
 np.random.seed(1)
 random.seed(1)
@@ -10,6 +10,50 @@ try:
     from sklearn.model_selection import train_test_split  # sklearn >= 0.18
 except ImportError:
     from sklearn.cross_validation import train_test_split  # sklearn < 0.18
+
+# define expected results for python2 and 3
+if sys.version_info[0] == 2:
+    golden_results_shallow_CNN = OrderedDict(
+        [('Loss', 0.70371496533279465),
+         ('Balanced accuracy', 55.639097744360896),
+         ('auROC', 0.50877192982456143),
+         ('auPRC', 0.58026674651508325),
+         ('Recall at 5% FDR', 9.5238095238095237),
+         ('Recall at 10% FDR', 9.5238095238095237),
+         ('Recall at 20% FDR', 9.5238095238095237),
+         ('Num Positives', 21),
+         ('Num Negatives', 19)])
+    golden_results_deep_CNN = OrderedDict(
+        [('Loss', 0.68411321005526782),
+         ('Balanced accuracy', 45.833333333333329),
+         ('auROC', 0.51822916666666663),
+         ('auPRC', 0.41738642611750432),
+         ('Recall at 5% FDR', 0.0),
+         ('Recall at 10% FDR', 0.0),
+         ('Recall at 20% FDR', 0.0),
+         ('Num Positives', 16),
+         ('Num Negatives', 24)])
+else:
+    golden_results_shallow_CNN = OrderedDict(
+        [('Loss', 0.81189359341516687),
+         ('Balanced accuracy', 30.82706766917293),
+         ('auROC', 0.20802005012531333),
+         ('auPRC', 0.36561113802048162),
+         ('Recall at 5% FDR', 0.0),
+         ('Recall at 10% FDR', 0.0),
+         ('Recall at 20% FDR', 0.0),
+         ('Num Positives', 21),
+         ('Num Negatives', 19)])
+    golden_results_deep_CNN = OrderedDict(
+        [('Loss', 0.7036767919621677),
+         ('Balanced accuracy', 43.75),
+         ('auROC', 0.43489583333333337),
+         ('auPRC', 0.34594783625646253),
+         ('Recall at 5% FDR', 0.0),
+         ('Recall at 10% FDR', 0.0),
+         ('Recall at 20% FDR', 0.0),
+         ('Num Positives', 16),
+         ('Num Negatives', 24)])
 
 
 def run(use_deep_CNN, use_RNN, label, golden_results):
@@ -44,28 +88,12 @@ def run(use_deep_CNN, use_RNN, label, golden_results):
 
 def test_shallow_CNN():
     run(use_deep_CNN=False, use_RNN=False, label='Shallow CNN',
-        golden_results=OrderedDict([('Loss', 0.70371496533279465),
-                                    ('Balanced accuracy', 55.639097744360896),
-                                    ('auROC', 0.50877192982456143),
-                                    ('auPRC', 0.58026674651508325),
-                                    ('Recall at 5% FDR', 9.5238095238095237),
-                                    ('Recall at 10% FDR', 9.5238095238095237),
-                                    ('Recall at 20% FDR', 9.5238095238095237),
-                                    ('Num Positives', 21),
-                                    ('Num Negatives', 19)]))
+        golden_results=golden_results_shallow_CNN)
 
 
 def test_deep_CNN():
     run(use_deep_CNN=True, use_RNN=False, label='Deep CNN',
-        golden_results=OrderedDict([('Loss', 0.68411321005526782),
-                                    ('Balanced accuracy', 45.833333333333329),
-                                    ('auROC', 0.51822916666666663),
-                                    ('auPRC', 0.41738642611750432),
-                                    ('Recall at 5% FDR', 0.0),
-                                    ('Recall at 10% FDR', 0.0),
-                                    ('Recall at 20% FDR', 0.0),
-                                    ('Num Positives', 16),
-                                    ('Num Negatives', 24)]))
+        golden_results=golden_results_deep_CNN)
 
 
 if __name__ == '__main__':

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,6 @@
+from shapely.wkt import loads as load_wkt
+
+def test_shapely():
+    # Example call from Shapely's test_affinity.py
+    # Don't want to fully test Shapley, but ensure it is available
+    load_wkt('LINESTRING(2.4 4.1, 2.4 3, 3 3)')

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,6 +1,0 @@
-from shapely.wkt import loads as load_wkt
-
-def test_shapely():
-    # Example call from Shapely's test_affinity.py
-    # Don't want to fully test Shapley, but ensure it is available
-    load_wkt('LINESTRING(2.4 4.1, 2.4 3, 3 3)')


### PR DESCRIPTION
Updates `.travis.yml` to run tests in a conda 2.7 and 3.5 environment as discussed in #26.  The unit tests currently fail in Python 3.5.  I allowed edits from maintainers in case you want to push to this branch, or you could create a new branch and merge there instead of master.