### PR TITLE
Fix readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,26 +21,26 @@ The `dragonn` package provides a simple command line interface to train DragoNN 
 dragonn train --pos-sequences examples/example_pos_sequences.fa --neg-sequences examples/example_neg_sequences.fa --prefix training_example
 ```
 
-This will store a model file, training_example.model.json, with the model architecture and a weights file, training_example.weights.hd5, with the parameters of the trained model. Test the model by running:
+This will store a model file, training_example.model.json, with the model architecture and a weights file, training_example.weights.h5, with the parameters of the trained model. Test the model by running:
 
 ```
-dragonn test --pos-sequences examples/example_pos_sequences.fa --neg-sequences examples/example_neg_sequences.fa --arch-file training_example.arch.json --weights-file training_example.weights.hd5
+dragonn test --pos-sequences examples/example_pos_sequences.fa --neg-sequences examples/example_neg_sequences.fa --arch-file training_example.arch.json --weights-file training_example.weights.h5
 ```
 
 This will print the model's test performance metrics. Model predictions on sequence data can be obtained by running:
 
 ```
-dragonn predict --sequences examples/example_pos_sequences.fa --arch-file training_example.arch.json --weights-file training_example.weights.hd5 --output-file example_predictions.txt
+dragonn predict --sequences examples/example_pos_sequences.fa --arch-file training_example.arch.json --weights-file training_example.weights.h5 --output-file example_predictions.txt
 ```
 
 This will store the model predictions for sequences in example_pos_sequences.fa in the output file example_predictions.txt. Interpret sequence data with a dragonn model by running:
 
 ```
-dragonn interpret --sequences examples/example_pos_sequences.fa --arch-file training_example.arch.json --weights-file training_example.weights.hd5 --prefix example_interpretation
+dragonn interpret --sequences examples/example_pos_sequences.fa --arch-file training_example.arch.json --weights-file training_example.weights.h5 --prefix example_interpretation
 ```
 
 This will write the most important subsequence in each input sequence along with its location in the input sequence in the file example_interpretation.task_0.important_sequences.txt.
-Note: by default, only examples with predicted positive class probability >0.5 are interpreted. Examples below this thershold yield important subsequence of Ns with location -1. This default can be changed with the flag --pos-thershold.
+Note: by default, only examples with predicted positive class probability >0.5 are interpreted. Examples below this threshold yield important subsequence of Ns with location -1. This default can be changed with the flag --pos-threshold.
 
 We encourage DragoNN users to share models in the [Model Zoo](https://github.com/kundajelab/dragonn/wiki/Model-Zoo). Enjoy!
 


### PR DESCRIPTION
Minor edits to the examples and instructions in `README.md`.  I assume the `hd5` file extension should be `h5` based on https://github.com/kundajelab/dragonn/blob/master/dragonn/models.py#L282