### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ before_install:
 install:
   # Create a conda environment for the desired Python version and install
   # the dependencies that pip cannot easily install on the Travis CI server
-  - conda create --yes --name dragonn-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION scipy matplotlib=1.5.3 pytest Shapely
+  - conda create --yes --name dragonn-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION \
+      scipy matplotlib=1.5.3 pytest Shapely mkl-service
   # Use the new environment
   - source activate dragonn-$TRAVIS_PYTHON_VERSION
   # Confirm the Python version

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 install:
   # Create a conda environment for the desired Python version and install
   # the dependencies that pip cannot easily install on the Travis CI server
-  - conda create --yes --name dragonn-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION \
+  - conda create --yes --name dragonn-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION
       scipy matplotlib=1.5.3 pytest Shapely mkl-service
   # Use the new environment
   - source activate dragonn-$TRAVIS_PYTHON_VERSION


### PR DESCRIPTION
For the past 4 months, all the dragonn travis builds have failed with this error (example from https://travis-ci.org/kundajelab/dragonn/jobs/368414761)
```
E           RuntimeError: 
E           Could not import 'mkl'.  Either install mkl-service with conda or set
E           MKL_THREADING_LAYER=GNU in your environment for MKL 2018.
E           
E           If you have MKL 2017 install and are not in a conda environment you
E           can set the Theano flag blas.check_openmp to False.  Be warned that if
E           you set this flag and don't set the appropriate environment or make
E           sure you have the right version you *will* get wrong results.
../../../miniconda/envs/dragonn-2.7/lib/python2.7/site-packages/theano/configdefaults.py:1262: RuntimeError
```
Adding `mkl-service` as an inline conda requirement in the travis build script fixes it.