### PR TITLE
Potential fix for 1-based nature of BQTL index

### DIFF
--- a/dragonn/generators.py
+++ b/dragonn/generators.py
@@ -214,10 +214,10 @@ class BQTLGenerator(DataGenerator):
             allele=row[self.allele_col]
             chrom=index[0]
             pos=index[1]
-            left_flank_start=pos-self.flank_size
-            left_flank_end=pos
-            right_flank_start=pos+1
-            right_flank_end=pos+self.flank_size
+            left_flank_start=(pos-1)-self.flank_size
+            left_flank_end=(pos-1)
+            right_flank_start=pos
+            right_flank_end=(pos+self.flank_size-1)
             left_seq=self.ref.fetch(chrom,left_flank_start,left_flank_end)
             right_seq=self.ref.fetch(chrom,right_flank_start,right_flank_end)
             seq=left_seq+allele+right_seq


### PR DESCRIPTION
Hey Anna, looking closely at tracks in the genome browser, I'm concerned that the bQTLs index may be treated as off-by-one in the current implementation. Recall that the bQTLs are 1-indexed. I've proposed a fix. I'll test it out and let you know if it works.

Specific example of the current issue:
<img width="511" alt="screen shot 2019-02-18 at 12 48 57 pm" src="https://user-images.githubusercontent.com/2302598/52975810-ca53e300-337b-11e9-96cd-b9750379dfa7.png">
